### PR TITLE
Bugfix/state.age is not defined when mapping state to props app.js line: 19

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ class App extends Component {
   }
 }
 
-const mapStateToProps = (state = {age: 21}) => {
+const mapStateToProps = (state = {age: 21,}) => {
   return {
     age: state.age
   };

--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ class App extends Component {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = (state = {age: 21}) => {
   return {
     age: state.age
   };


### PR DESCRIPTION
> Your code through runtime error that state.age is not defined. 
> To solve this when you mapStateToProps you could have passed some default value to the state.

**here: -------** 

```
const mapStateToProps = (state = {age: 21}) => { 
return { age: state.age } 
};
```

Error stage Image:
![image](https://user-images.githubusercontent.com/24524924/91181065-1b2d6000-e706-11ea-933e-947428154304.png)
